### PR TITLE
Adding OXI One

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -902,3 +902,11 @@ _:ziqal-dimension-mk3  device:inputs 1 .
 _:ziqal-dimension-mk3  device:typeA true .
 _:ziqal-dimension-mk3  device:notes "Wavetable Processor" .
 _:ziqal-dimension-mk3  device:uri "https://ziqal.com/?v=d3dcf429c679" .
+
+_:oxiinstruments-oxi-one  device:make "OXI Instruments" .
+_:oxiinstruments-oxi-one  device:model "OXI One" .
+_:oxiinstruments-oxi-one  device:inputs 1 .
+_:oxiinstruments-oxi-one  device:outputs 1 .
+_:oxiinstruments-oxi-one  device:typeA true .
+_:oxiinstruments-oxi-one  device:notes "Grid Sequencer" .
+_:oxiinstruments-oxi-one  device:uri "https://oxiinstruments.com/oxi-one/" .


### PR DESCRIPTION
As per the manual (https://oxiinstruments.com/oxi-one/manual/):
```
INPUTS AND OUTPUTS
· MIDI TRS input and output (Din adapter included).

...

ACCESSORIES

INCLUDED IN THE PACKAGE
· MIDI DIN to TRS adapter (Black color) Type A
```