### PR TITLE
kinotone: ribbons; 1010music: lemondrop

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -270,6 +270,15 @@ _:1010music-euroshield1 device:typeB true .
 _:1010music-euroshield1 device:notes "Synthesizer and Effects Development Board" .
 _:1010music-euroshield1 device:uri "https://1010music.com/product/euroshield1" .
 
+_:1010music-lemondrop device:make "1010music" .
+_:1010music-lemondrop device:model "Lemondrop" .
+_:1010music-lemondrop device:inputs 1 .
+_:1010music-lemondrop device:outputs 1 .
+_:1010music-lemondrop device:typeA true .
+_:1010music-lemondrop device:typeB true .
+_:1010music-lemondrop device:details "MIDI IN autodetects type A or B; MIDI OUT is only type B (OUT is only MIDI THRU as of v1.1.2)" .
+_:1010music-lemondrop device:uri "https://1010music.com/product/lemondrop" .
+
 # ADDAC System ADDAC221 (I/O; Polarity Korg)
 # per muffwiggler thread. could not find confirmation of type on the addac systems site.
 _:addac-addac221 device:make "ADDAC" .

--- a/devices.ttl
+++ b/devices.ttl
@@ -929,3 +929,12 @@ _:sds-digital-k-accord-melisma device:model "Accord Melisma" .
 _:sds-digital-k-accord-melisma device:outputs 1 .
 _:sds-digital-k-accord-melisma device:typeA true .
 _:sds-digital-k-accord-melisma device:uri "https://freshnelly.com/melisma/melisma.htm" .
+
+_:kinotone-ribbons device:make "Kinotone" .
+_:kinotone-ribbons device:model "Ribbons" .
+_:kinotone-ribbons device:inputs 1 .
+_:kinotone-ribbons device:swappable true .
+_:kinotone-ribbons device:typeA true .
+_:kinotone-ribbons device:typeB true .
+_:kinotone-ribbons device:details "Internal jumpers select TRS MIDI variant: A (factory default), B, or CBA (Chase Bliss)" .
+_:kinotone-ribbons device:uri "https://kinotoneaudio.com/products/ribbons" .


### PR DESCRIPTION
Kinotone Ribbons

Supports A & B (and CBA) via jumper. https://kinotoneaudio.com/ribbons-manual/#MIDIOverview
Have indicated factory default in 'details' field.

I've used the 'swappable' field, though it only seems to have been used twice in the past.

-----

1010music Lemondrop

Autodetects A or B on MIDI IN per manual, and my own testing with Roland UM-ONE, MIDI-OX and a handful of dongles.
Manual: https://1010music.com/wp-content/uploads/2022/02/nanobox-lemondrop-User-Guide.pdf

MIDI OUT however is just Type B per my tests. Additionally it is really just MIDI THRU - there's no discussion in the manual, but a [recent forum thread](https://forum.1010music.com/forum/products/nanobox-product-discussions/nanobox-lemondrop-compact-granular-synthesizer/support-lemondrop/43012-midi-clock-out) confirms this as do my own tests.

I omitted 'swappable' for this device, but have left both A and B as true with details in the 'details' field.

I assume the Fireball and Razzmatazz are the same, but I don't own them and therefore cannot test them to confirm.