### PR TITLE
adding xor-electronics-2hp-trs-a-midi-expander

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -947,3 +947,12 @@ _:kinotone-ribbons device:typeA true .
 _:kinotone-ribbons device:typeB true .
 _:kinotone-ribbons device:details "Internal jumpers select TRS MIDI variant: A (factory default), B, or CBA (Chase Bliss)" .
 _:kinotone-ribbons device:uri "https://kinotoneaudio.com/products/ribbons" .
+
+_:xor-electronics-2hp-trs-a-midi-expander device:make "XOR Electronics"
+_:xor-electronics-2hp-trs-a-midi-expander device:model "2HP TRS-A Midi Expander"
+_:xor-electronics-2hp-trs-a-midi-expander device:inputs 1 .
+_:xor-electronics-2hp-trs-a-midi-expander device:outputs 2 .
+_:xor-electronics-2hp-trs-a-midi-expander device:typeA true .
+_:xor-electronics-2hp-trs-a-midi-expander device:notes "MIDI Expander for the Nerdseq"
+_:xor-electronics-2hp-trs-a-midi-expander device:details "Second output switchable to thru."
+_:xor-electronics-2hp-trs-a-midi-expander device:uri "https://xor-electronics.com/product/nerdseq-2hp-trs-a-midi-expander/"


### PR DESCRIPTION
As the name already implies it uses TRS-A, but still missing from the list none the less ;)