### PR TITLE
support Boss SL-2 Slicer pedal

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -817,6 +817,14 @@ _:audiothingies-micromonsta-2 device:typeA true .
 _:audiothingies-micromonsta-2 device:notes "Dual polyphonic synthesizer" .
 _:audiothingies-micromonsta-2 device:uri "https://www.audiothingies.com/product/micromonsta2" .
 
+_:boss-sl-2 device:make "Boss" .
+_:boss-sl-2 device:model "SL-2 Slicer" .
+_:boss-sl-2 device:inputs 1 .
+_:boss-sl-2 device:outputs 1 .
+_:boss-sl-2 device:typeA true .
+_:boss-sl-2 device:notes "Audio chopper guitar pedal" .
+_:boss-sl-2 device:uri "https://www.boss.info/global/products/sl-2/" .
+
 _:roland-sp-404-mk2 device:make "Roland" .
 _:roland-sp-404-mk2 device:model "SP-404MKII" .
 _:roland-sp-404-mk2 device:inputs 1 .


### PR DESCRIPTION
data for the [Boss SL-2 Slicer](https://www.boss.info/global/products/sl-2/).

README says:

> When submitting a PR, please try to comment with a link to an official source (manufacturer page url, link to manual with associated page number, etc) that documents the TRS MIDI type (A or B) used by the device.

unfortunately, though, I only found out this project exists because Boss doesn't document this, as far as I can tell.

this is anecdoatally what works, it's [what works according to Reddit](https://old.reddit.com/r/guitarpedals/comments/z2yn7w/anyone_got_the_new_boss_sl2_is_the_the_lack_of/jpw5obm/), and it's the same configuration as all the other Roland gear in this file. (Roland owns Boss.)