### PR TITLE
modern sounds: pluto

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -1057,10 +1057,10 @@ _:maudio-oxygen-pro-mini device:outputs 1 .
 _:maudio-oxygen-pro-mini device:typeA true .
 _:maudio-oxygen-pro-mini device:uri "https://m-audio.com/oxygen-pro-mini" .
 
-_:modern-sounds-pluto device:make "Modern Sounds"
-_:modern-sounds-pluto device:model "Pluto"
+_:modern-sounds-pluto device:make "Modern Sounds" .
+_:modern-sounds-pluto device:model "Pluto" .
 _:modern-sounds-pluto device:inputs 1 .
 _:modern-sounds-pluto device:outputs 1 .
 _:modern-sounds-pluto device:typeA true .
-_:modern-sounds-pluto device:details "Early Plutos manufactured before 2023 had a single MIDI jack with a slide switch to choose between IN and OUT." .
+_:modern-sounds-pluto device:details "Early Plutos manufactured before 2023 had a single TRS MIDI jack with a slide switch to choose between IN and OUT." .
 _:modern-sounds-pluto device:uri "https://www.modernsounds.co/pluto" .

--- a/devices.ttl
+++ b/devices.ttl
@@ -1056,3 +1056,11 @@ _:maudio-oxygen-pro-mini device:model "Oxygen Pro Mini" .
 _:maudio-oxygen-pro-mini device:outputs 1 .
 _:maudio-oxygen-pro-mini device:typeA true .
 _:maudio-oxygen-pro-mini device:uri "https://m-audio.com/oxygen-pro-mini" .
+
+_:modern-sounds-pluto device:make "Modern Sounds"
+_:modern-sounds-pluto device:model "Pluto"
+_:modern-sounds-pluto device:inputs 1 .
+_:modern-sounds-pluto device:outputs 1 .
+_:modern-sounds-pluto device:typeA true .
+_:modern-sounds-pluto device:details "Early Plutos manufactured before 2023 had a single MIDI jack with a slide switch to choose between IN and OUT." .
+_:modern-sounds-pluto device:uri "https://www.modernsounds.co/pluto" .


### PR DESCRIPTION
Type A indicated on page 5 of the manual: http://files.modernsounds.co/pluto_manual_oct_2023.pdf

Added details about early versions only having a single switchable MIDI jack.