### PR TITLE
Add M-live B.Beat Multitrack Player

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -1064,3 +1064,14 @@ _:modern-sounds-pluto device:outputs 1 .
 _:modern-sounds-pluto device:typeA true .
 _:modern-sounds-pluto device:details "Early Plutos manufactured before 2023 had a single TRS MIDI jack with a slide switch to choose between IN and OUT." .
 _:modern-sounds-pluto device:uri "https://www.modernsounds.co/pluto" .
+
+_:mlive-bbeat device:make "M-live" .
+_:mlive-bbeat device:model "B.Beat" .
+_:mlive-bbeat device:inputs 0 .
+_:mlive-bbeat device:outputs 1 .
+_:mlive-bbeat device:thrus 0 .
+_:mlive-bbeat device:swappable false .
+_:mlive-bbeat device:typeA false .
+_:mlive-bbeat device:typeB true .
+_:mlive-bbeat device:notes "Multitrack player with MIDI and video" .
+_:mlive-bbeat device:uri "https://www.m-live.com/en/b-beat/" .


### PR DESCRIPTION
Hi there,

I'm currently making a cable for the [M-live B.Beat](https://www.m-live.com/en/b-beat/) and didn't find it in your awesome list of TRS-MIDI devices.

The type gets mentioned in the manual as "Mini Jack 3.5 mm Cable Type-B". I also had the original adapter from M-live laying around and measured the pinout.