### PR TITLE
reliq instruments: reliq

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -1137,3 +1137,11 @@ _:mvave-smc-pad device:typeB false .
 _:mvave-smc-pad device:notes "16-pad controller" .
 _:mvave-smc-pad device:uri "https://www.cuvave.com/productinfo/1106104.html" .
 _:mvave-smc-pad device:eurorack false .
+
+_:reliq-reliq device:make "Reliq Instruments" .
+_:reliq-reliq device:model "Reliq" .
+_:reliq-reliq device:inputs 1 .
+_:reliq-reliq device:outputs 3 .
+_:reliq-reliq device:typeA true .
+_:reliq-reliq device:details "MIDI IN autodetects type A or B; MIDI OUTs are only type A" .
+_:reliq-reliq device:uri "https://reliq-instruments.com/pages/reliq" .


### PR DESCRIPTION
I have this device, but details are here: https://manual.reliq-instruments.com/chapters/technical-specifications.html
Yes, company and product name are the same.

I only set `typeA` to true, not `typeB`. Since the (3!) outputs are all type A and the input is autodetect, just `typeA` seems more appropriate, along with the additional details comment. If you disagree, please let me know.