### PR TITLE
Added Tasty Chips Integral, updated 1010 Lemondrop

### DIFF
--- a/devices.ttl
+++ b/devices.ttl
@@ -1179,6 +1179,14 @@ _:oxi-instruments-oxi-coral device:typeB true .
 _:oxi-instruments-oxi-coral device:notes "Polyphonic Eurorack oscillator" .
 _:oxi-instruments-oxi-coral device:uri "https://oxiinstruments.com/oxi-coral" .
 
+_:tasty-chips-integral device:make "Tasty Chips" .
+_:tasty-chips-integral device:model "Integral" .
+_:tasty-chips-integral device:inputs 1 .
+_:tasty-chips-integral device:typeA true .
+_:tasty-chips-integral device:notes "Dual convolution reverb" .
+_:tasty-chips-integral device:details "2025 and newer models have a switch to turn the Expression jack into a type A MIDI jack" .
+_:tasty-chips-integral device:uri "https://www.tastychips.nl/product/integral/" .
+
 _:m-vave-smk-37-pro device:make "M-Vave" .
 _:m-vave-smk-37-pro device:model "SMK-37 PRO" .
 _:m-vave-smk-37-pro device:inputs 0 .

--- a/devices.ttl
+++ b/devices.ttl
@@ -287,7 +287,9 @@ _:1010music-lemondrop device:inputs 1 .
 _:1010music-lemondrop device:outputs 1 .
 _:1010music-lemondrop device:typeA true .
 _:1010music-lemondrop device:typeB true .
-_:1010music-lemondrop device:details "MIDI IN autodetects type A or B; MIDI OUT is only type B (OUT is only MIDI THRU as of v1.1.2)" .
+_:1010music-lemondrop device:swappable true .
+_:1010music-lemondrop device:notes "Granular synthesizer" .
+_:1010music-lemondrop device:details "MIDI IN autodetects type A or B; MIDI OUT is configurable as type A or B as of v1.2.28 (OUT is only MIDI THRU)" .
 _:1010music-lemondrop device:uri "https://1010music.com/product/lemondrop" .
 
 # ADDAC System ADDAC221 (I/O; Polarity Korg)


### PR DESCRIPTION
Lemondrop 1.2.28 release notes noting type A/B configurable for midi out: https://1010music.com/downloads

Integral manual: https://www.tastychips.nl/downloads/Integral/UserManual/Integral_Manual_3_2_b.pdf
"The expression socket on Integrals produced from 2025 onward is dual purpose, with the switch next to it
selecting its function. To use an expression pedal, put the switch in its outward position. Pressing it in allows
you to hook it up to MIDI, for more information see the chapter “MIDI”."
(A sticker on the back of the device indicates type A.)